### PR TITLE
Use Alpine Linux for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.7
+FROM python:3.7-alpine
 
 VOLUME ["/in", "/out"]
 
 RUN python -m pip install inotify \
-			&& adduser copyuser --disabled-password --disabled-login --no-create-home --gecos ""
+			&& adduser copyuser -D -H -g ""
 
 COPY --chown=copyuser:copyuser script.py /
 COPY entrypoint.sh /


### PR DESCRIPTION
I switched the base image for the Dockerfile to use a Python image built on top of Alpine Linux. On my system the resulting image size was much smaller and the build time was much less.

| Base Image      | Build Time | Image Size |
|----------------|-----------|------------|
| Debian Buster | 1m47s        | 926MB       |
| Alpine Linux    | 10s             | 103MB        |